### PR TITLE
Implement demo vagrant plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tmp
 .files
 *.tar.gz
 pkg
+.demo

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+require File.join File.dirname(__FILE__), 'base', 'utils', 'demo'
+
 case Vagrant::VERSION
 when /^1\.[1-4]/
   Vagrant.require_plugin('oscar')
@@ -8,30 +10,9 @@ else
   # The require_plugin call is deprecated in 1.5.x. Replacement? Dunno.
 end
 
-def demos
-  demo_list = ['base']
-  demo_list = String(ENV['demo']).split(',')
-  $demos = demo_list.flatten
-end
-
-def vagrantdir
-  File.dirname(__FILE__)
-end
-
-def demodirs 
-  configdirs = Array.new
-  configdirs << File.expand_path('base', vagrantdir)
-
-  demos.each do |demo|
-    configdirs << File.expand_path(demo, vagrantdir)
-  end
-
-  configdirs
-end
+include ::Demo
 
 if defined? Oscar
-  require File.join(vagrantdir, 'base', 'utils', 'config_builder_overrides')
-  require File.join(vagrantdir, 'base', 'utils', 'oscar_overrides')
 
   class ReloadPluginSupport < ::ConfigBuilder::Model::Base
     def to_proc
@@ -43,5 +24,5 @@ if defined? Oscar
     ::ConfigBuilder::Model::Provisioner.register('reload', self)
   end
   
-  Vagrant.configure('2', &Oscar.run(demodirs))
+  Vagrant.configure('2', &Oscar.run(demo_directories))
 end

--- a/base/demo.yaml
+++ b/base/demo.yaml
@@ -1,0 +1,6 @@
+---
+demo:
+  base:
+    directory: 'base'
+    description: "A single PE monolithic master VM"
+    info_url: 'http://confluence.puppetlabs.com/some/path/to/docs'

--- a/base/utils/demo.rb
+++ b/base/utils/demo.rb
@@ -1,0 +1,43 @@
+require 'vagrant'
+require File.join File.dirname(__FILE__), 'demo', 'plugin'
+require File.join File.dirname(__FILE__), 'demo', 'helpers'
+require File.join File.dirname(__FILE__), 'config_builder_overrides'
+require File.join File.dirname(__FILE__), 'oscar_overrides'
+
+module Demo
+
+  extend  Demo::Helpers
+  include Demo::Helpers
+
+  def load_directories(demo)
+    directories = Array.new
+    directories << Array(demo['directory'])
+
+    if demo.key?('inherits')
+      directories << load_directories(demos[demo['inherits']])
+    end
+
+    directories
+  end
+
+  def vagrantdir
+    File.join(File.dirname(__FILE__), '..', '..')
+  end
+
+  def demo_directories
+    Demo::loaded_demos.map do |demo|
+      load_directories demo
+    end.flatten.uniq
+  end
+
+  def self.loaded_demos
+    saved_demos = IO.read(File.join(vagrantdir, '.demo')).split
+    demo_list = Array.new
+
+    saved_demos.each do |saved_demo|
+      demo_list << demos[saved_demo]
+    end
+
+    demo_list
+  end
+end

--- a/base/utils/demo.rb
+++ b/base/utils/demo.rb
@@ -11,7 +11,8 @@ module Demo
 
   def load_directories(demo)
     directories = Array.new
-    directories << Array(demo['directory'])
+    demo_directory = File.join(vagrantdir, demo['directory'])
+    directories << demo_directory
 
     if demo.key?('inherits')
       directories << load_directories(demos[demo['inherits']])

--- a/base/utils/demo/command.rb
+++ b/base/utils/demo/command.rb
@@ -1,0 +1,41 @@
+module Demo
+  class Command < Vagrant.plugin(2, :command)
+
+    Dir[File.join File.dirname(__FILE__), 'command', '*'].each do |lib|
+      require lib
+    end
+
+    include Demo::Helpers
+
+    def initialize(argv, env)
+      @argv     = argv
+      @env      = env
+      @cmd_name = 'demo'
+
+      split_argv
+      register_subcommands
+    end
+
+    def execute
+      invoke_subcommand
+    end
+
+    private
+
+    def register_subcommands
+      @subcommands = Vagrant::Registry.new
+
+      @subcommands.register('list') do
+        Demo::Command::List
+      end
+
+      @subcommands.register('show') do
+        Demo::Command::Show
+      end
+
+      @subcommands.register('use') do
+        Demo::Command::Use
+      end
+    end
+  end
+end

--- a/base/utils/demo/command/helpers.rb
+++ b/base/utils/demo/command/helpers.rb
@@ -1,0 +1,107 @@
+require 'yaml'
+
+module Demo::Command::Helpers
+
+  private
+
+  def split_argv
+    @main_args, @subcommand, @sub_args = split_main_and_subcommand(@argv)
+  end
+
+  def parse_demos(argv)
+    argv.last.split(',')
+  end
+
+  def print_current_demo
+    puts "Current loaded demos: #{current_demos.join(',')}\n\n"
+  end
+
+  def ensure_demos_exist(passed_demos)
+    passed_demos = Array(passed_demos)
+    missing_demos = Array.new
+
+    passed_demos.each do |demo|
+      missing_demos << demo unless demos.key?(demo)
+    end
+
+    if missing_demos.size > 0
+      puts "Err: The following demos don't exist. Run `vagrant demo list` to see available demos"
+      puts missing_demos
+      exit 1
+    end
+  end
+
+  def current_demos
+    demo_file = File.join(project_root, '.demo')
+
+    if File.exists? demo_file
+      IO.read(demo_file).split
+    else
+      'base'
+    end
+  end
+
+  def demos
+    return @demos if @demos
+
+    @demos = Hash.new
+
+    demo_config_files.each do |demo|
+      demo_config = YAML::load(IO.read(demo))['demo']
+      @demos.merge! demo_config
+    end
+
+    @demos
+  end
+
+  def demo_config_files
+    demo_search_path = File.join(project_root, '**', 'demo.yaml')
+    Dir[demo_search_path]
+  end
+
+  def project_root
+    return @project_root if @project_root
+
+    cur_path = File.dirname(__FILE__).split(File::SEPARATOR)
+    count = cur_path.size
+    count.times do
+      path = cur_path
+      vagrantfile = File.join(path, 'Vagrantfile')
+      if File.exists?(vagrantfile)
+        @project_root = path
+        break
+      else
+        cur_path.pop
+      end
+    end
+
+    @project_root
+  end
+
+  def invoke_subcommand
+    if @subcommand and (klass = @subcommands.get(@subcommand))
+      klass.new(@argv, @env).execute
+    elsif @subcommand
+      @env.ui.error "Unrecognized subcommand: #{@subcommand}"
+      print_subcommand_help(:error)
+    else
+      print_subcommand_help
+    end
+  end
+
+  def print_subcommand_help(output = :info)
+    msg = []
+    msg << "Usage: vagrant #{@cmd_name} <command> [<args>]"
+    msg << ''
+    msg << 'Available subcommands:'
+
+    keys = []
+    @subcommands.each { |(key, _)| keys << key }
+    msg += keys.sort.map { |key| "     #{key}" }
+
+    msg << ''
+    msg << "For help on any individual command run `vagrant #{@cmd_name} <command> -h`"
+
+    @env.ui.send(output, msg.join("\n"))
+  end
+end

--- a/base/utils/demo/command/list.rb
+++ b/base/utils/demo/command/list.rb
@@ -1,0 +1,41 @@
+require 'pp'
+require 'json'
+
+module Demo
+  class Command::List < Vagrant.plugin('2', :command)
+
+    include Demo::Command::Helpers
+
+    def initialize(argv, env)
+      @argv     = argv
+      @env      = env
+      @cmd_name = 'demo list'
+
+      @provider = nil
+
+      split_argv
+    end
+
+    def execute
+      argv = parse_options(parser)
+      print_current_demo
+
+      puts "Available Demos:"
+      puts demos.keys.map { |k| "* #{k}\n" }
+    end
+
+    private
+
+    def parser
+      OptionParser.new do |o|
+        o.banner = "Usage: vagrant #{@cmd_name} [<args>]"
+        o.separator ''
+
+        o.on('-h', '--help', 'Display this help message') do
+          puts o
+          exit 0
+        end
+      end
+    end
+  end
+end

--- a/base/utils/demo/command/show.rb
+++ b/base/utils/demo/command/show.rb
@@ -1,0 +1,58 @@
+require 'pp'
+require 'json'
+
+module Demo
+  class Command::Show< Vagrant.plugin('2', :command)
+
+    include Demo::Command::Helpers
+
+    def initialize(argv, env)
+      @argv     = argv
+      @env      = env
+      @cmd_name = 'demo show'
+
+      @provider = nil
+
+      split_argv
+    end
+
+    def execute
+      argv = parse_options(parser)
+      demo = argv.last
+
+      print_current_demo
+
+      unless argv.size == 2
+        puts "Usage: vagrant #{@cmd_name} [demo name]"
+        exit 1
+      end
+
+      ensure_demos_exist(demo)
+
+      metadata = demos[demo]
+
+      description = metadata['description'] || String.new
+      info_url    = metadata['info_url']    || String.new
+      parent_demo = metadata['parent_demo'] || 'base'
+
+
+      puts demo.capitalize
+      puts '  ' + info_url unless info_url.empty?
+      puts '  ' + description unless description.empty?
+    end
+
+    private
+
+    def parser
+      OptionParser.new do |o|
+        o.banner = "Usage: vagrant #{@cmd_name} [demo name]"
+        o.separator ''
+
+        o.on('-h', '--help', 'Display this help message') do
+          puts o
+          exit 0
+        end
+      end
+    end
+  end
+end

--- a/base/utils/demo/command/use.rb
+++ b/base/utils/demo/command/use.rb
@@ -1,0 +1,49 @@
+require 'pp'
+require 'json'
+
+module Demo
+  class Command::Use < Vagrant.plugin('2', :command)
+
+    include Demo::Command::Helpers
+
+    def initialize(argv, env)
+      @argv     = argv
+      @env      = env
+      @cmd_name = 'demo use'
+
+      @provider = nil
+
+      split_argv
+    end
+
+    def execute
+      argv = parse_options(parser)
+      demos = parse_demos(argv)
+
+      unless argv.size == 2
+        puts "Usage: vagrant #{@cmd_name} [comma separate list of demos]"
+        exit 1
+      end
+
+      ensure_demos_exist(demos)
+
+      File.open(File.join(project_root, '.demo'), 'w') { |f| f.write demos.join("\n") }
+
+      puts "You can now load #{demos.join(',')} with `vagrant up`"
+    end
+
+    private
+
+    def parser
+      OptionParser.new do |o|
+        o.banner = "Usage: vagrant #{@cmd_name} [comma separated list of demos]"
+        o.separator ''
+
+        o.on('-h', '--help', 'Display this help message') do
+          puts o
+          exit 0
+        end
+      end
+    end
+  end
+end

--- a/base/utils/demo/helpers.rb
+++ b/base/utils/demo/helpers.rb
@@ -1,0 +1,107 @@
+require 'yaml'
+
+module Demo::Helpers
+
+  private
+
+  def split_argv
+    @main_args, @subcommand, @sub_args = split_main_and_subcommand(@argv)
+  end
+
+  def parse_demos(argv)
+    argv.last.split(',')
+  end
+
+  def print_current_demo
+    puts "Current loaded demos: #{current_demos.join(',')}\n\n"
+  end
+
+  def ensure_demos_exist(passed_demos)
+    passed_demos = Array(passed_demos)
+    missing_demos = Array.new
+
+    passed_demos.each do |demo|
+      missing_demos << demo unless demos.key?(demo)
+    end
+
+    if missing_demos.size > 0
+      puts "Err: The following demos don't exist. Run `vagrant demo list` to see available demos"
+      puts missing_demos
+      exit 1
+    end
+  end
+
+  def current_demos
+    demo_file = File.join(project_root, '.demo')
+
+    if File.exists? demo_file
+      IO.read(demo_file).split
+    else
+      'base'
+    end
+  end
+
+  def demos
+    return @demos if @demos
+
+    @demos = Hash.new
+
+    demo_config_files.each do |demo|
+      demo_config = YAML::load(IO.read(demo))['demo']
+      @demos.merge! demo_config
+    end
+
+    @demos
+  end
+
+  def demo_config_files
+    demo_search_path = File.join(project_root, '**', 'demo.yaml')
+    Dir[demo_search_path]
+  end
+
+  def project_root
+    return @project_root if @project_root
+
+    cur_path = File.dirname(__FILE__).split(File::SEPARATOR)
+    count = cur_path.size
+    count.times do
+      path = cur_path
+      vagrantfile = File.join(path, 'Vagrantfile')
+      if File.exists?(vagrantfile)
+        @project_root = path
+        break
+      else
+        cur_path.pop
+      end
+    end
+
+    @project_root
+  end
+
+  def invoke_subcommand
+    if @subcommand and (klass = @subcommands.get(@subcommand))
+      klass.new(@argv, @env).execute
+    elsif @subcommand
+      @env.ui.error "Unrecognized subcommand: #{@subcommand}"
+      print_subcommand_help(:error)
+    else
+      print_subcommand_help
+    end
+  end
+
+  def print_subcommand_help(output = :info)
+    msg = []
+    msg << "Usage: vagrant #{@cmd_name} <command> [<args>]"
+    msg << ''
+    msg << 'Available subcommands:'
+
+    keys = []
+    @subcommands.each { |(key, _)| keys << key }
+    msg += keys.sort.map { |key| "     #{key}" }
+
+    msg << ''
+    msg << "For help on any individual command run `vagrant #{@cmd_name} <command> -h`"
+
+    @env.ui.send(output, msg.join("\n"))
+  end
+end

--- a/base/utils/demo/plugin.rb
+++ b/base/utils/demo/plugin.rb
@@ -1,0 +1,12 @@
+require 'vagrant'
+
+module Demo
+  class Plugin < Vagrant.plugin('2')
+    name 'demo'
+
+    command(:demo) do
+      require_relative "command"
+      Demo::Command
+    end
+  end
+end

--- a/satellite/demo.yaml
+++ b/satellite/demo.yaml
@@ -1,0 +1,7 @@
+---
+demo:
+  satellite:
+    inherits: 'base'
+    directory: 'satellite'
+    description: 'RH Satellite and Puppet Enterprise integration demo'
+    info_url: 'http://confluence.puppetlabs.com/some/path/to/docs'


### PR DESCRIPTION
This commit introduces a vagrant plugin called demo to list and select
available demo environemnts.  It works by loading all demo.yaml files it
finds and parsing the metadata to learn the directory of the oscar files
for the demo environment.
