### PR TITLE
Properly build hosts file

### DIFF
--- a/satellite/scripts/install_satellite.sh
+++ b/satellite/scripts/install_satellite.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
 if ! [ -d /opt/satellite ]; then
+  export dnsdomainname=`cat /etc/resolv.conf | grep domain | awk '{ print $2 }'`
+  export hostname=`hostname`
+  sed -i -- 's/^127.0.1.1.*//' /etc/hosts
+  sed -i -- "s/$hostname/$hostname.$dnsdomainname $hostname/" /etc/hosts
+
   mkdir -p /mnt/iso
   curl http://osmirror.delivery.puppetlabs.net/iso/satellite-6.0.4-rhel-7-x86_64-dvd.iso > /tmp/satellite-6.0.4-rhel-7-x86_64-dvd.iso
   mount /tmp/satellite-6.0.4-rhel-7-x86_64-dvd.iso -o loop /mnt/iso


### PR DESCRIPTION
The automated installation of Satellite failed due to hostname -f and facter fqdn returning different results.  This PR adds the management of the /etc/hosts file to the install_satellite.sh script. 
