### PR TITLE
List parent VMs first

### DIFF
--- a/base/utils/demo.rb
+++ b/base/utils/demo.rb
@@ -11,12 +11,13 @@ module Demo
 
   def load_directories(demo)
     directories = Array.new
-    demo_directory = File.join(vagrantdir, demo['directory'])
-    directories << demo_directory
 
     if demo.key?('inherits')
       directories << load_directories(demos[demo['inherits']])
     end
+
+    demo_directory = File.join(vagrantdir, demo['directory'])
+    directories << demo_directory
 
     directories
   end


### PR DESCRIPTION
Prior to this commit, if a demo environment inherited another
environment, the parent's VMs would be listed last, which can cause
problems in boot order.  This commit parses parent environments first
