### PR TITLE
Use r10k to deploy Puppetfile

### DIFF
--- a/base/puppet/manifests/git_repos.pp
+++ b/base/puppet/manifests/git_repos.pp
@@ -2,8 +2,13 @@ Vcsrepo {
   ensure   => present,
   provider => git,
   notify   => Exec['deploy r10k'],
+  require  => Package['git'],
 }
   
+package { 'git':
+  ensure => installed,
+}
+
 vcsrepo { '/var/lib/peadmin/site':
   source   => 'https://github.com/puppetlabs-pmmteam/puppet-site.git',
 }

--- a/base/roles.yaml_erb
+++ b/base/roles.yaml_erb
@@ -19,13 +19,21 @@ roles:
         autosign: true
       - type: shell
         inline: |-
-          which git; [ $? == 0 ] || puppet resource package git ensure=installed
-          ( [ -f /opt/puppetlabs/puppet/bin/librarian-puppet ] || /opt/puppetlabs/puppet/bin/gem install librarian-puppet );
           ( /opt/puppetlabs/puppet/bin/gem list | grep puppetclassify || /opt/puppetlabs/puppet/bin/gem install puppetclassify );
           <% Oscar.config_dir.each do |configdir| %>
           <% demodir = File.basename(configdir) %>
-          cd /vagrant/<%= demodir %>/puppet && /opt/puppetlabs/puppet/bin/librarian-puppet install
-          /opt/puppetlabs/puppet/bin/puppet apply --modulepath /vagrant/<%= demodir %>/puppet/modules:/opt/puppetlabs/puppet/modules /vagrant/<%= demodir %>/puppet/manifests
+          if [ -d /vagrant/<%= demodir %>/puppet ]; then
+            cd /vagrant/<%= demodir %>/puppet 
+            if [ -f /vagrant/<%= demodir %>/puppet/Puppetfile ]; then
+              /opt/puppetlabs/bin/r10k puppetfile install
+            fi
+
+            if [ -d /vagrant/<%= demodir %>/puppet/manifests ]; then
+              /opt/puppetlabs/puppet/bin/puppet apply \
+                --modulepath /vagrant/<%= demodir %>/puppet/modules:/opt/puppetlabs/puppet/modules \
+                /vagrant/<%= demodir %>/puppet/manifests
+            fi
+          fi
           <% end %>
   agent:
     private_networks:


### PR DESCRIPTION
This PR cleans up the master role, removing the need to install librarian-puppet.
