### PR TITLE
Make demo more stable on different networks. Simplify classification.

### DIFF
--- a/app_orchestration/demo_site.pp
+++ b/app_orchestration/demo_site.pp
@@ -2,16 +2,16 @@ site {
   # rgbank { 'staging':
   #   web_count => 2,
   #   nodes     => {
-  #     Node['appserver01']  => [ Rgbank::Web['staging-0'] ],
-  #     Node['appserver02']  => [ Rgbank::Web['staging-1'] ],
-  #     Node['loadbalancer'] => [ Rgbank::Load['staging'] ],
-  #     Node['database']     => [ Rgbank::Db['staging'] ],
+  #     Node['appserver01.vm']  => [ Rgbank::Web['staging-0'] ],
+  #     Node['appserver02.vm']  => [ Rgbank::Web['staging-1'] ],
+  #     Node['loadbalancer.vm'] => [ Rgbank::Load['staging'] ],
+  #     Node['database.vm']     => [ Rgbank::Db['staging'] ],
   #   },
   # }
   #
   # rgbank { 'dev':
   #   nodes               => {
-  #     Node['rgbankdev'] => [ Rgbank::Web['dev-0'],
+  #     Node['rgbankdev.vm'] => [ Rgbank::Web['dev-0'],
   #                            Rgbank::Load['dev'],
   #                            Rgbank::Db['dev'] ],
   #   },

--- a/app_orchestration/puppet/manifests/node_groups.pp
+++ b/app_orchestration/puppet/manifests/node_groups.pp
@@ -2,11 +2,7 @@ node_group { 'Load Balancers':
   ensure      => 'present',
   classes     => { 'haproxy' => {} },
   environment => 'production',
-  rule        => ['or', 
-                   ['and', ['=', ['fact', 'role'], 'loadbalancer']], 
-                   ['=', 'name', 'rgbankdev.delivery.puppetlabs.net'],
-                   ['=', 'name', 'rgbankdev']
-                 ],
+  rule        => ['and', ['~', ['fact', 'role'], 'loadbalancer']],
   parent      => 'All Nodes',
 }
 
@@ -19,30 +15,22 @@ node_group { 'App Servers':
                    'git'                  => {},
   },
   environment => 'production',
-  rule        => ['or', 
-                   ['and', ['=', ['fact', 'role'], 'appserver']], 
-                   ['=', 'name', 'rgbankdev.delivery.puppetlabs.net'],
-                   ['=', 'name', 'rgbankdev']
-                 ],
+  rule        => ['and', ['~', ['fact', 'role'], 'appserver']],
   parent      => 'All Nodes',
 }
 
 node_group { 'Database Servers':
   ensure      => 'present',
-  classes     => { 'mysql::server' => { 
+  classes     => { 'mysql::server' => {
                      'override_options' => {
                        'mysqld' => {
-                         'bind-address' => '0.0.0.0' 
+                         'bind-address' => '0.0.0.0'
                        }
                      }
                  },
                  'git' => {},
   },
   environment => 'production',
-  rule        => ['or', 
-                   ['and', ['=', ['fact', 'role'], 'database']], 
-                   ['=', 'name', 'rgbankdev.delivery.puppetlabs.net'],
-                   ['=', 'name', 'rgbankdev']
-                 ],
+  rule        => ['and', ['~', ['fact', 'role'], 'database']],
   parent      => 'All Nodes',
 }

--- a/app_orchestration/roles.yaml
+++ b/app_orchestration/roles.yaml
@@ -15,3 +15,8 @@ roles:
       - type: shell
         inline: |-
           mkdir -p /etc/puppetlabs/facter/facts.d; echo "role=loadbalancer" > /etc/puppetlabs/facter/facts.d/role.txt
+  all:
+    provisioners:
+      - type: shell
+        inline: |-
+          mkdir -p /etc/puppetlabs/facter/facts.d; echo "role=loadbalancer,appserver,database" > /etc/puppetlabs/facter/facts.d/role.txt

--- a/app_orchestration/vms.yaml
+++ b/app_orchestration/vms.yaml
@@ -14,4 +14,4 @@ vms:
     roles: [ "agent", "loadbalancer" ]
   - name: "rgbankdev.vm"
     box:  "puppetlabs/centos-7.0-64-nocm"
-    roles: [ "agent" ]
+    roles: [ "agent", "all" ]

--- a/app_orchestration/vms.yaml
+++ b/app_orchestration/vms.yaml
@@ -1,17 +1,17 @@
 ---
 vms:
-  - name: "database"
+  - name: "database.vm"
     box:  "puppetlabs/centos-7.0-64-nocm"
     roles: [ "agent", "database" ]
-  - name: "appserver01"
+  - name: "appserver01.vm"
     box:  "puppetlabs/centos-7.0-64-nocm"
     roles: [ "agent", "appserver" ]
-  - name: "appserver02"
+  - name: "appserver02.vm"
     box:  "puppetlabs/centos-7.0-64-nocm"
     roles: [ "agent", "appserver" ]
-  - name: "loadbalancer"
+  - name: "loadbalancer.vm"
     box:  "puppetlabs/centos-7.0-64-nocm"
     roles: [ "agent", "loadbalancer" ]
-  - name: "rgbankdev"
+  - name: "rgbankdev.vm"
     box:  "puppetlabs/centos-7.0-64-nocm"
     roles: [ "agent" ]


### PR DESCRIPTION
This PR consists of two commits. One changes the names of all vms in the app_orchestration demo stack, except for `master` to `<name>.vm`. This is because the vagrant hosts plugin will interpret this as the fqdn and you won't get `rgbankdev.delivery.puppetlabs.net` at work vs `rgbank.foo.comcast.net` at home, etc. I've updated the demo_site.pp accordingly.

The other commit simplifies the node groups to regex match for `role` fact of `loadbalancer`,`appserver`, or `database` as appropriate, and gives the all-in-one dev machine the role of `all` which has the corresponding fact of `role=loadbalancer,appserver,database`. That way you don't need to pin both `rgbankdev` and `rgbankdev.delivery.puppetlabs.net` and whatever else to the node groups to make it work.
